### PR TITLE
Fix for wrong repositioning

### DIFF
--- a/lib/mongoid/tree/ordering.rb
+++ b/lib/mongoid/tree/ordering.rb
@@ -165,6 +165,7 @@ module Mongoid
       end
 
       def reposition_former_siblings
+        return unless persisted?
         former_siblings = base_class.where(:parent_id => attribute_was('parent_id')).
                                      and(:position.gt => (attribute_was('position') || 0)).
                                      excludes(:id => self.id)


### PR DESCRIPTION
Hi Benedikt. I solved the problem found in this paste:
http://pastie.org/1323370

With this commit's change, the specs pass using both 1.8.7 and 1.9.2 . However, I can't guarantee that this doesn't break something else, since the specs don't check all edge cases. Can you think of anything that this commit's change might negatively affect?
