### PR TITLE
Use :validate => false on relations with Mongoid 2.0.0.rc

### DIFF
--- a/lib/mongoid/tree.rb
+++ b/lib/mongoid/tree.rb
@@ -300,7 +300,7 @@ module Mongoid # :nodoc:
         self.parent_ids = []
       end
 
-      rearrange_children! if self.parent_ids_changed?
+      rearrange_children! if self.persisted? && self.parent_ids_changed?
     end
 
     def rearrange_children


### PR DESCRIPTION
Mongoid 2.0.0.rc.1+ will, by default, validate all of its relations on save. In the future it should be smart enough to NOT go load something from the database just to validate it, but today it is not, which makes for updating trees even more expensive than it needs to be.
