### PR TITLE
Ancestors are returned in their correct order when using Tree::Ordering

### DIFF
--- a/lib/mongoid/tree/ordering.rb
+++ b/lib/mongoid/tree/ordering.rb
@@ -43,6 +43,12 @@ module Mongoid
       end
 
       ##
+      # Returns a chainable criteria for this document's ancestors
+      def ancestors
+        base_class.unscoped.where(:_id.in => parent_ids)
+      end
+
+      ##
       # Returns siblings below the current document.
       # Siblings with a position greater than this documents's position.
       def lower_siblings

--- a/spec/mongoid/tree/ordering_spec.rb
+++ b/spec/mongoid/tree/ordering_spec.rb
@@ -164,6 +164,20 @@ describe Mongoid::Tree::Ordering do
         node(:third_root).first_sibling_in_list.should == node(:first_root)
       end
     end
+
+    describe 'ancestors' do
+      it "#ancestors should be returned in the correct order" do
+        setup_tree <<-ENDTREE
+          - root:
+            - level_1_a
+            - level_1_b:
+              - level_2_a:
+                - leaf
+        ENDTREE
+
+        node(:leaf).ancestors.to_a.should == [node(:root), node(:level_1_b), node(:level_2_a)]
+      end
+    end
   end
 
   describe 'moving nodes around' do


### PR DESCRIPTION
Hey there, Benedikt. I just found a bug with ancestors and Tree::Ordering.

If you have a tree like this:

```
- root:
  - level_1_a
  - level_1_b:
    - level_2_a:
      - leaf
```

`leaf.ancestors` returns `[root, level_2_a, level_1_b]`, which is obviously incorrect.

This occurs because of the default scope of ascending position. `level_2_a`'s position is 0, `level_1_b`'s position 1, so MongoDB sorts `level_2_a` before `level_1_b`.

The solution is to make Tree::Ordering query the base class _unscoped_.

Cheers,
Nick
