### PR TITLE
Do not require a block for traversal, return an array of nodes instead

### DIFF
--- a/lib/mongoid/tree/traversal.rb
+++ b/lib/mongoid/tree/traversal.rb
@@ -76,9 +76,9 @@ module Mongoid # :nodoc:
       # They're extended into the base class automatically.
       module ClassMethods # :nodoc:
         def traverse(type = :depth_first, &block)
-          raise ArgumentError, "No block given" unless block_given?
-          roots.each { |root| root.traverse(type, &block) }
-          nil
+          res = []
+          roots.each { |root| res.concat root.traverse(type, &block) }
+          res
         end
       end
 
@@ -95,8 +95,10 @@ module Mongoid # :nodoc:
       #     results << node
       #   end
       def traverse(type = :depth_first, &block)
-        raise ArgumentError, "No block given" unless block_given?
+        res = []
+        block ||= lambda { |node| res << node }
         send("#{type}_traversal", &block)
+        res
       end
 
       private


### PR DESCRIPTION
So that you can append other enumerable methods: Node.traverse.map(&:name)
