### PR TITLE
When traversing with a block, return an array of the block's results.

### DIFF
--- a/lib/mongoid/tree/traversal.rb
+++ b/lib/mongoid/tree/traversal.rb
@@ -76,9 +76,7 @@ module Mongoid # :nodoc:
       # They're extended into the base class automatically.
       module ClassMethods # :nodoc:
         def traverse(type = :depth_first, &block)
-          res = []
-          roots.each { |root| res.concat root.traverse(type, &block) }
-          res
+          roots.map { |root| root.traverse(type, &block) }.flatten
         end
       end
 
@@ -98,17 +96,16 @@ module Mongoid # :nodoc:
       #   root.traverse(:depth_first).map(&:name)
       #
       def traverse(type = :depth_first, &block)
-        res = []
-        block ||= lambda { |node| res << node }
+        block ||= lambda { |node| node }
         send("#{type}_traversal", &block)
-        res
       end
 
       private
 
       def depth_first_traversal(&block)
-        block.call(self)
-        self.children.each { |c| c.send(:depth_first_traversal, &block) }
+        res = [block.call(self)]
+        self.children.each { |c| res << c.send(:depth_first_traversal, &block) }
+        res.flatten
       end
 
       def breadth_first_traversal(&block)


### PR DESCRIPTION
This pull request is for [this discussion](https://github.com/benedikt/mongoid-tree/commit/f16725ea85c0e8c427138f183219ff02abec40f1#commitcomment-971209).

When traversing with a block, return an array of the block's results. Eg:

``` ruby
Node.traverse { |n| n.name }
# => ["level 1", "level 1.1", "level 1.2", "level 1.2.1"]
```

This is instead of always returning the nodes.
Note that the behaviour of traversing without a block hasn't changed. In other words, the nodes are returned in an array.
