### PR TITLE
Reordering nodes can cause #ancestor to give results out of order

### DIFF
--- a/lib/mongoid/tree/ordering.rb
+++ b/lib/mongoid/tree/ordering.rb
@@ -47,7 +47,7 @@ module Mongoid
       #
       # @return [Mongoid::Criteria] Mongoid criteria to retrieve the document's ancestors
       def ancestors
-        base_class.unscoped.where(:_id.in => parent_ids)
+        base_class.unscoped.where(:_id.in => parent_ids).order_by(:depth => 1)
       end
 
       ##

--- a/spec/mongoid/tree/ordering_spec.rb
+++ b/spec/mongoid/tree/ordering_spec.rb
@@ -177,6 +177,25 @@ describe Mongoid::Tree::Ordering do
 
         node(:leaf).ancestors.to_a.should == [node(:root), node(:level_1_b), node(:level_2_a)]
       end
+
+      it "#ancestors should be returned in the correct order even after rearranging" do
+        root = OrderedNode.create(name: "root")
+        a = OrderedNode.create(name: "a")
+        b = OrderedNode.create(name: "b")
+        leaf = OrderedNode.create(name: "leaf")
+
+        leaf.parent = b; leaf.save
+        b.parent = a; b.save
+        a.parent = root; a.save
+
+        leaf.ancestors.to_a.should == [root, a, b]
+
+        leaf.parent = a; leaf.save
+        a.parent = b; a.save
+        b.parent = root; b.save
+
+        leaf.ancestors.to_a.should == [root, b, a]
+      end
     end
   end
 

--- a/spec/mongoid/tree_spec.rb
+++ b/spec/mongoid/tree_spec.rb
@@ -278,6 +278,25 @@ describe Mongoid::Tree do
         node(:subchild).ancestors_and_self.to_a.should == [node(:root), node(:child), node(:subchild)]
       end
 
+      it "#ancestors should be returned in the correct order even after rearranging" do
+        root = Node.create(name: "root")
+        a = Node.create(name: "a")
+        b = Node.create(name: "b")
+        leaf = Node.create(name: "leaf")
+
+        leaf.parent = b; leaf.save
+        b.parent = a; b.save
+        a.parent = root; a.save
+
+        leaf.ancestors.to_a.should == [root, a, b]
+
+        leaf.parent = a; leaf.save
+        a.parent = b; a.save
+        b.parent = root; b.save
+
+        leaf.ancestors.to_a.should == [root, b, a]
+      end
+
       describe '#ancestor_of?' do
         it "should return true for ancestors" do
           node(:child).should be_ancestor_of(node(:subchild))


### PR DESCRIPTION
Here's some sample output. 

This is the order that my parent ids are stored in the array:

```
irb(main):018:0> page.parent_ids
=> ["515c547c392d4ecdf6000004", "515c5732392d4ecdf600003a", "51d1f63fd268d9289600037c", "515c5740392d4ecdf60000f1"]
```

This is the order that they are returned by #ancestors:

```
irb(main):004:0> page.ancestors.map(&:id)
=> ["515c547c392d4ecdf6000004", "515c5732392d4ecdf600003a", "515c5740392d4ecdf60000f1", "51d1f63fd268d9289600037c"]
```

You'll notice the last 2 are flipped.

It seems that when no sort order is specified, MongoDB returns documents based on the order that they are stored in the disk: http://docs.mongodb.org/manual/reference/glossary/#term-natural-order

It seems to me that the least computationally expensive way to do this is to add a depth field, which may come in handy other places as well. I'm not very experienced with mongodb, so if anyone has a better suggestion I'm very open to it.
