### PR TITLE
Change the default ordering scope to be a proc wrapped critera

### DIFF
--- a/lib/mongoid/tree/ordering.rb
+++ b/lib/mongoid/tree/ordering.rb
@@ -35,7 +35,7 @@ module Mongoid
       included do
         field :position, :type => Integer
 
-        default_scope asc(:position)
+        default_scope ->{ asc(:position) }
 
         before_save :assign_default_position, :if => :assign_default_position?
         before_save :reposition_former_siblings, :if => :sibling_reposition_required?


### PR DESCRIPTION
In new mongoid ordering is not working because of change how the scopes are defined.
