### PR TITLE
Adds activesupport as runtime dependency.

### DIFF
--- a/lib/mongoid/tree.rb
+++ b/lib/mongoid/tree.rb
@@ -1,3 +1,5 @@
+require 'active_support/concern'
+
 module Mongoid
   ##
   # = Mongoid::Tree


### PR DESCRIPTION
I had problems using your gem without Rails. Loading a model which includes `Mongoid::Tree` fails with

```
NameError: uninitialized constant Mongoid::Tree::ActiveSupport
```

This commit fixes the dependency.
