### PR TITLE
Travis: Use jruby-9.1.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: ruby
 rvm:
   - 2.2.5
   - 2.3.1
-  - jruby
+  - jruby-9.1.7.0
 services:
   - mongodb
 matrix:


### PR DESCRIPTION
This PR changes the build matrix to use latest stable JRuby.