### PR TITLE
Travis: jruby-9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: ruby
 rvm:
   - 2.2.5
   - 2.3.1
-  - jruby-9.1.10.0
+  - jruby-9.1.13.0
 services:
   - mongodb
 matrix:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html