### PR TITLE
Support for mongoid 7.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   include:
-    - rvm: 2.3.1
-      env: MONGOID_VERSION=4
+    # - rvm: 2.3.1
+    #   env: MONGOID_VERSION=4
     - rvm: 2.3.1
       env: MONGOID_VERSION=5
     - rvm: 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
   allow_failures:
     - rvm: ruby-head
   include:
-    # - rvm: 2.3.1
-    #   env: MONGOID_VERSION=4
+    - rvm: 2.3.1
+      env: MONGOID_VERSION=4
     - rvm: 2.3.1
       env: MONGOID_VERSION=5
     - rvm: 2.3.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
     - rvm: ruby-head
   include:
     - rvm: 2.3.1
-      env: MONGOID_VERSION=3
-    - rvm: 2.3.1
       env: MONGOID_VERSION=4
     - rvm: 2.3.1
       env: MONGOID_VERSION=5

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,14 @@ services:
 matrix:
   allow_failures:
     - rvm: ruby-head
+  include:
+    - rvm: 2.3.1
+      env: MONGOID_VERSION=3
+    - rvm: 2.3.1
+      env: MONGOID_VERSION=4
+    - rvm: 2.3.1
+      env: MONGOID_VERSION=5
+    - rvm: 2.3.1
+      env: MONGOID_VERSION=6
+    - rvm: 2.3.1
+      env: MONGOID_VERSION=7

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,14 @@ source 'https://rubygems.org'
 
 gemspec
 
+case version = ENV['MONGOID_VERSION'] || '~> 7.0'
+when 'HEAD' then gem 'mongoid', github: 'mongodb/mongoid'
+when /7/    then gem 'mongoid', '~> 7.0'
+when /6/    then gem 'mongoid', '~> 6.0'
+when /5/    then gem 'mongoid', '~> 5.1'
+else             gem 'mongoid', version
+end
+
 unless ENV['CI']
   gem 'guard-rspec', '>= 0.6.0'
   gem 'ruby_gntp',   '>= 0.3.4'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ case version = ENV['MONGOID_VERSION'] || '~> 7.0'
 when 'HEAD' then gem 'mongoid', github: 'mongodb/mongoid'
 when /7/    then gem 'mongoid', '~> 7.0'
 when /6/    then gem 'mongoid', '~> 6.0'
-when /5/    then gem 'mongoid', '~> 5.1'
+when /5/    then gem 'mongoid', '~> 5.0'
+when /4/    then gem 'mongoid', '~> 4.0'
 else             gem 'mongoid', version
 end
 

--- a/mongoid-tree.gemspec
+++ b/mongoid-tree.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.files         = Dir.glob('{lib,spec}/**/*') + %w(LICENSE README.md Rakefile Gemfile .rspec)
 
   s.add_runtime_dependency('mongoid', ['<= 7.0', '>= 4.0'])
+  s.add_development_dependency('mongoid-compatibility')
   s.add_development_dependency('rake', ['>= 0.9.2'])
   s.add_development_dependency('rspec', ['~> 3.0'])
   s.add_development_dependency('yard', ['~> 0.8'])

--- a/mongoid-tree.gemspec
+++ b/mongoid-tree.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files         = Dir.glob('{lib,spec}/**/*') + %w(LICENSE README.md Rakefile Gemfile .rspec)
 
-  s.add_runtime_dependency('mongoid', ['< 7.0', '>= 4.0'])
+  s.add_runtime_dependency('mongoid', ['<= 7.0', '>= 4.0'])
   s.add_development_dependency('rake', ['>= 0.9.2'])
   s.add_development_dependency('rspec', ['~> 3.0'])
   s.add_development_dependency('yard', ['~> 0.8'])

--- a/mongoid-tree.gemspec
+++ b/mongoid-tree.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files         = Dir.glob('{lib,spec}/**/*') + %w(LICENSE README.md Rakefile Gemfile .rspec)
 
-  s.add_runtime_dependency('mongoid', ['<= 7.0', '>= 4.0'])
+  s.add_runtime_dependency('mongoid', ['>= 4.0', '< 8'])
   s.add_development_dependency('mongoid-compatibility')
   s.add_development_dependency('rake', ['>= 0.9.2'])
   s.add_development_dependency('rspec', ['~> 3.0'])

--- a/spec/mongoid/tree_spec.rb
+++ b/spec/mongoid/tree_spec.rb
@@ -7,7 +7,11 @@ describe Mongoid::Tree do
   it "should reference many children as inverse of parent with index" do
     a = Node.reflect_on_association(:children)
     expect(a).to be
-    expect(a.macro).to eq(:has_many)
+    if Mongoid::Compatibility::Version.mongoid7?
+      expect(a).to be_kind_of(Mongoid::Association::Referenced::HasMany)
+    else
+      expect(a.macro).to eq(:has_many)
+    end
     expect(a.class_name).to eq('Node')
     expect(a.foreign_key).to eq('parent_id')
     expect(Node.index_specification(:parent_id => 1)).to be
@@ -16,7 +20,11 @@ describe Mongoid::Tree do
   it "should be referenced in one parent as inverse of children" do
     a = Node.reflect_on_association(:parent)
     expect(a).to be
-    expect(a.macro).to eq(:belongs_to)
+    if Mongoid::Compatibility::Version.mongoid7?
+      expect(a).to be_kind_of(Mongoid::Association::Referenced::BelongsTo)
+    else
+      expect(a.macro).to eq(:belongs_to)
+    end
     expect(a.class_name).to eq('Node')
     expect(a.inverse_of).to eq(:children)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'bundler/setup'
 
 require 'mongoid'
 require 'mongoid/tree'
+require 'mongoid-compatibility'
 
 require 'rspec'
 

--- a/spec/support/logger.rb
+++ b/spec/support/logger.rb
@@ -1,3 +1,9 @@
 FileUtils.mkdir_p File.expand_path('../../../log', __FILE__)
 
-Mongoid.logger = Mongo::Logger.logger = Logger.new('log/mongoid.log')
+logger = Logger.new('log/mongoid.log')
+
+if Mongoid::Compatibility::Version.mongoid5_or_newer?
+  Mongoid.logger = Mongo::Logger.logger = logger
+else
+  Mongoid.logger = logger
+end


### PR DESCRIPTION
Adding support for `mongoid 7.0.0` did not require any changes to the code, but a small change to the `tree_spec.rb` was needed.

In `mongoid 7.0.0` `Node.reflect_on_association` no longer has the `.macro`. So instead of testing against `.macro` I tested the type of the reflection. In order to just do this on 7 I added the `mongoid-compabilitity` gem as a development dependency.

I also updated `Gemfile` and `.travis.yml` to make travis test against multiple mongoid versions (4..7).