### PR TITLE
Check for presence of parent when rearranging

### DIFF
--- a/lib/mongoid/tree.rb
+++ b/lib/mongoid/tree.rb
@@ -431,7 +431,7 @@ module Mongoid
     # @private
     # @return [undefined]
     def rearrange
-      if self.parent_id
+      if parent.present?
         self.parent_ids = parent.parent_ids + [self.parent_id]
       else
         self.parent_ids = []

--- a/spec/mongoid/tree_spec.rb
+++ b/spec/mongoid/tree_spec.rb
@@ -328,9 +328,9 @@ describe Mongoid::Tree do
                   - subsubchild
           ENDTREE
 
-          filtered_ancestors = node(:subsubchild).ancestors.or(
-              { :name => 'child' },
-              { :name => 'subchild' }
+          filtered_ancestors = node(:subsubchild).ancestors.any_of(
+            { :name => 'child' },
+            { :name => 'subchild' }
           )
 
           expect(filtered_ancestors.to_a).to eq([node(:child), node(:subchild)])


### PR DESCRIPTION
In my project I use `mongoid-tree` in conjunction with `mongoid-archivable` (which adds soft-delete functionality to mongoid documents) and I've run into an issue.

When I'm restoring a deleted document, it tries to save the document, which runs the `:before_validation` callbacks defined in `mongoid-tree` and calls `save` on all of its children. Since the parent document is not stored when `rearrange` is called on the child, I run into an awkward situation where `parent` is nil, but `parent_id` is present...

The fix is quite simple luckily – instead of checking for presence of `self.parent_id` in `rearrange`, we check for presence of `parent`. Since we are calling a method on `parent` I think it makes sense to check that it exists, even if we think we could safely assume it from the existence of `self.parent_id`.

Also included is a fix of a test which was failing in mongoid 7. As far as I can tell the test was using the `or` criteria incorrectly and changing it to `any_of` fixed the test (which from what I could tell was actually the correct criteria to use).

By the way, would you be interested in a PR which moves CI to GitHub?