### PR TITLE
bump mongoid version to 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tree structure for Mongoid documents using the materialized path pattern
 
 ## Requirements
 
-* mongoid (>= 4.0, < 8.0)
+* mongoid (>= 4.0, < 9.0)
 
 For a mongoid 3.x compatible version, please use mongoid-tree 1.0.x,
 for a mongoid 2.x compatible version, please use mongoid-tree 0.7.x.

--- a/mongoid-tree.gemspec
+++ b/mongoid-tree.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files         = Dir.glob('{lib,spec}/**/*') + %w(LICENSE README.md Rakefile Gemfile .rspec)
 
-  s.add_runtime_dependency('mongoid', ['>= 4.0', '< 8'])
+  s.add_runtime_dependency('mongoid', ['>= 4.0', '< 9'])
   s.add_development_dependency('mongoid-compatibility')
   s.add_development_dependency('rake', ['>= 0.9.2'])
   s.add_development_dependency('rspec', ['~> 3.0'])


### PR DESCRIPTION
mongoid tree isn't using anything version relveant that would break so it's safe to use with mongoid 8.x